### PR TITLE
[Doppins] Upgrade dependency Django to ==1.9.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.9.7
+Django==1.9.8
 django-auth-abakus==1.1.0
 django-crispy-forms==1.6.0
 psycopg2==2.6.2


### PR DESCRIPTION
Hi!

A new version was just released of `Django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Django from `==1.9.7` to `==1.9.8`
